### PR TITLE
added openssl config load before openssl init

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -53,8 +53,9 @@ int index_session_authenticated, index_session_connect_address;
 int ssl_init(void) { /* init TLS before parsing configuration file */
 #if OPENSSL_VERSION_NUMBER>=0x10100000L
     OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS |
-        OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL);
+        OPENSSL_INIT_LOAD_CRYPTO_STRINGS | OPENSSL_INIT_LOAD_CONFIG, NULL);
 #else
+    OPENSSL_config( NULL );
     SSL_load_error_strings();
     SSL_library_init();
 #endif


### PR DESCRIPTION
We tried to use the original stunnel with our openssl engine, which provides GOST ciphersuites support, but met a problem.

If we do not bind our engine before openssl init, then openssl init can not find our ciphersuites and there is no way to add them after that:
- 1.0.2: https://github.com/openssl/openssl/blob/OpenSSL_1_0_2-stable/ssl/ssl_ciph.c#L425
- 1.1.0: https://github.com/openssl/openssl/blob/OpenSSL_1_1_0-stable/ssl/ssl_ciph.c#L439

Can you support engines loading before initialization through this request?