### PR TITLE
Bug fix : bad malloc

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -120,7 +120,7 @@ DISK_FILE *file_open(char *name, FILE_MODE mode) {
         return NULL;
 
     /* setup df structure */
-    df=str_alloc(sizeof df);
+    df=str_alloc(sizeof *df);
     df->fd=fd;
     return df;
 }


### PR DESCRIPTION
FILE_DISK is essentially fd (in linux ) , df is *fd , calling str_alloc on df leads to error , fixing it by passing *df