### PR TITLE
Add the "socks_ssl" protocol, it secures the remote connection instead of the local connection

### DIFF
--- a/src/ctx.c
+++ b/src/ctx.c
@@ -139,7 +139,7 @@ typedef long SSL_OPTIONS_TYPE;
 int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
     /* create TLS context */
 #if OPENSSL_VERSION_NUMBER>=0x10100000L
-    if(section->option.client)
+    if(section->option.client || section->option.protocol_before_connect)
         section->ctx=SSL_CTX_new(TLS_client_method());
     else /* server mode */
         section->ctx=SSL_CTX_new(TLS_server_method());

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -156,7 +156,7 @@ int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
         return 1; /* FAILED */
     }
 #else /* OPENSSL_VERSION_NUMBER<0x10100000L */
-    if(section->option.client)
+    if(section->option.client || section->option.protocol_before_connect)
         section->ctx=SSL_CTX_new(section->client_method);
     else /* server mode */
         section->ctx=SSL_CTX_new(section->server_method);

--- a/src/network.c
+++ b/src/network.c
@@ -728,6 +728,29 @@ void fd_putline(CLI *c, SOCKET fd, const char *line) {
     s_log(LOG_DEBUG, " -> %s", line);
 }
 
+char *fd_getstring(CLI *c, SOCKET fd) { /* get null-terminated string */
+    char *line;
+    size_t ptr=0, allocated=32;
+
+    line=str_alloc(allocated);
+    for(;;) {
+        if(ptr>65536) { /* >64KB --> DoS protection */
+            s_log(LOG_ERR, "ssl_getstring: Line too long");
+            str_free(line);
+            throw_exception(c, 1);
+        }
+        if(allocated<ptr+1) {
+            allocated*=2;
+            line=str_realloc(line, allocated);
+        }
+        s_read(c, fd, line+ptr, 1);
+        if(line[ptr]=='\0')
+            break;
+        ++ptr;
+    }
+    return line;
+}
+
 char *fd_getline(CLI *c, SOCKET fd) {
     char *line;
     size_t ptr=0, allocated=32;

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -329,6 +329,7 @@ typedef struct service_options_struct {
         unsigned reset:1;               /* reset sockets on error */
         unsigned renegotiation:1;
         unsigned connect_before_ssl:1;
+        unsigned protocol_before_connect:1;
 #ifndef OPENSSL_NO_OCSP
         unsigned aia:1;                 /* Authority Information Access */
         unsigned nonce:1;               /* send and verify OCSP nonce */
@@ -625,6 +626,7 @@ int s_connect(CLI *, SOCKADDR_UNION *, socklen_t);
 void s_write(CLI *, SOCKET fd, const void *, size_t);
 void s_read(CLI *, SOCKET fd, void *, size_t);
 void fd_putline(CLI *, SOCKET, const char *);
+char *fd_getstring(CLI *, SOCKET);
 char *fd_getline(CLI *, SOCKET);
 /* descriptor versions of fprintf/fscanf */
 void fd_printf(CLI *, SOCKET, const char *, ...)
@@ -638,6 +640,21 @@ void s_ssl_read(CLI *, void *, int);
 char *ssl_getstring(CLI *c);
 char *ssl_getline(CLI *c);
 void ssl_putline(CLI *c, const char *);
+
+#define cli_local_read(cli, dest, size) \
+  (cli->ssl? \
+      s_ssl_read(cli, dest, size) : \
+      s_read(cli, cli->local_rfd.fd, dest, size))
+
+#define cli_local_write(cli, src, size) \
+  (cli->ssl? \
+      s_ssl_write(cli, src, size) : \
+      s_write(cli, cli->local_wfd.fd, src, size))
+
+#define cli_local_getstring(cli) \
+  (cli->ssl? \
+      ssl_getstring(cli) : \
+      fd_getstring(cli, cli->local_rfd.fd))
 
 /**************************************** prototype for protocol.c */
 


### PR DESCRIPTION
Right now stunnel can't be used as a socks server to reach TLS-only endpoints. For example, using this config file:

```
[socks_server]
protocol = socks
accept = 1081
PSKsecrets = stunnel.secrets

[socks_client]
client = yes
accept = 1080
connect =  localhost:1081
PSKSecrets = stunnel.secrets
```

and simulating a non-TLS capable system as follows:

    curl --proxy "socks4://localhost:1080" "http://www.konamiman.com:443"

then I would expect to receive the home page of the site, but what I get instead is `400 The plain HTTP request was sent to HTTPS port`. That's because when runing as a socks server stunnel uses TLS to secure the local connection, but the connection to the target endpoint is made in plain TCP.

This defeats the whole purpose of stunnel, which is "to add TLS encryption functionality to existing clients and servers without any changes in the programs' code", for the cases where we need to run it in socks server mode.

The proper fix for this would be to secure both the local and the remote connection, but this would require to manage two ssl endpoints where the application is currently designed for only one. Instead, I decided to implement a simpler workaround: using plain TCP for the socks negotiation and TLS for connecting to the target hosts, thus "reversing" the current behavior.

I have done this by adding a new protocol, named `socks_ssl` (suggestions for a better name welcome), so that you can use this configuration:

```
[socks_ssl_server]
protocol = socks_ssl
accept = 1080
PSKsecrets = stunnel.secrets
```

...and then the `curl` example above will work as expected, retrieving the contents of the page.

### Some context on why this is needed

I'm a big fan of [MSX computers](https://en.wikipedia.org/wiki/MSX). Many years ago another enthusiast of the platform developed ObsoNET, a network card for these computers; and I developed InterNestor, the TCP/IP stack to make the most of it.

![image](https://user-images.githubusercontent.com/937723/61103802-8c806400-a4ae-11e9-9907-b3bced574daf.png)

Implementing TLS in InterNestor is out of the question because a Z80 can't handle the required encryption algorithms, so running stunnel on another computer (or even a Raspberry Pi) in the same network is a great alternative for connecting to TLS-only services. However, having to configure a client endpoint for each service is somewhat cumbersome, so my plan is to add socks client capabilities to InterNestor and then use stunnel as a socks server... but for that to work I need stunnel to TLS-ify the remote connection when running as such.