### PR TITLE
Use network-online.target in the service file

### DIFF
--- a/tools/stunnel.service.in
+++ b/tools/stunnel.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=TLS tunnel for network daemons
-After=syslog.target network.target
+After=syslog.target network-online.target
 
 [Service]
 ExecStart=@bindir@/stunnel


### PR DESCRIPTION
 stunnel starts before the network interface gets assigned an ip  with network.target used in the service file.

Use network-online.target in the service file instead.

{Steps to reproduce:
systemctl enable stunnel and reboot}

Signed-off-by: Sahana Prasad <sahana@redhat.com>