### PR TITLE
Adding passwd option

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -2404,6 +2404,32 @@ NOEXPORT char *parse_service_option(CMD cmd, SERVICE_OPTIONS **section_ptr,
         break;
     }
 
+    /* passwd */
+    switch(cmd) {
+    case CMD_SET_DEFAULTS:
+        section->passwd=NULL;
+        break;
+    case CMD_SET_COPY:
+        section->passwd=str_dup_detached(new_service_options.passwd);
+        break;
+    case CMD_FREE:
+        str_free(section->passwd);
+        break;
+    case CMD_SET_VALUE:
+        if(strcasecmp(opt, "passwd"))
+            break;
+        str_free(section->passwd);
+        section->passwd=str_dup_detached(arg);
+	return NULL; /* OK */
+    case CMD_INITIALIZE:
+        break;
+    case CMD_PRINT_DEFAULTS:
+        break;
+    case CMD_PRINT_HELP:
+        s_log(LOG_NOTICE, "%-22s = password to private key", "passwd");
+        break;
+    }
+
     /* protocol */
     switch(cmd) {
     case CMD_SET_DEFAULTS:

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -239,6 +239,7 @@ typedef struct service_options_struct {
 #endif /* TLS 1.3 */
     char *cert;                                             /* cert filename */
     char *key;                               /* pem (priv key/cert) filename */
+    char *passwd;                               /* passwd to key (if requested) */
     long session_size, session_timeout;
 #if OPENSSL_VERSION_NUMBER>=0x10100000L
     int security_level;


### PR DESCRIPTION
Hello!

I implemented a passwd option to specify password/PIN using config file. I added it because I faced into with the following problem.

I'm creating a patch for [SSLSocks](https://github.com/comp500/SSLSocks) project. This patch allows to use engines for android. Our company develops own openssl engine (rtengine) for working with our Rutoken smart cards. My final goal is to enable using rtengine, but I'm unable to set password to smart card through android GUI. The reasons is the following:
1. SSLSocks starts the stunnel as a separate application and reads it output. It cannot know when the password is requested.
2. I unable to set the password to a smart card using engineCtrl, because rtengine doesn't have this option.

I've found the only solution. So, my only solution is adding the passwd option to the stunnel config file.

I know that you are going to add the andoid GUI in the future, but, I still think that this option might be useful now and in the future. Also, dangers of this option could be eliminated by using correct permissions to the config file.