### PR TITLE
fix mac compilation by defining environ

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -1399,7 +1399,7 @@ NOEXPORT SOCKET connect_local(CLI *c) { /* spawn local process */
 
 #else /* standard Unix version */
 
-#ifndef HAVE_UNISTD_H
+#if !defined(HAVE_UNISTD_H) || defined(__APPLE__)
 extern char **environ;
 #endif
 


### PR DESCRIPTION
Macos doesn't have environ declared, despite have unistd, which causes compilation to fail on macos. Here we define it on apple platforms, which fixes compilation. I also ran the resulting stunnel binary to confirm it works for my typical use-case.

Someone also reported a similar issue on Solaris 10 SPARC (https://www.mail-archive.com/stunnel-users@stunnel.org/msg02802.html), but I don't have such a platform to test on.