### PR TITLE
check the result of SSL_CTX creation

### DIFF
--- a/src/ctx.c
+++ b/src/ctx.c
@@ -177,11 +177,11 @@ int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
         section->ctx=SSL_CTX_new(section->client_method);
     else /* server mode */
         section->ctx=SSL_CTX_new(section->server_method);
-#endif /* OPENSSL_VERSION_NUMBER<0x10100000L */
     if(!section->ctx) {
         sslerror("SSL_CTX_new");
         return 1; /* FAILED */
     }
+#endif /* OPENSSL_VERSION_NUMBER<0x10100000L */
 
     /* allow callbacks to access their SERVICE_OPTIONS structure */
     if(!SSL_CTX_set_ex_data(section->ctx, index_ssl_ctx_opt, section)) {

--- a/src/ctx.c
+++ b/src/ctx.c
@@ -152,6 +152,12 @@ int context_init(SERVICE_OPTIONS *section) { /* init TLS context */
     section->ctx=SSL_CTX_new(section->option.client ?
         TLS_client_method() : TLS_server_method());
 #endif /* OPENSSL_VERSION_NUMBER>=0x30000000L */
+    if(section->ctx==NULL) {
+        s_log(LOG_ERR, "Failed to create SSL context (FIPS %s)",
+	    EVP_default_properties_is_fips_enabled(NULL) ? "enabled" :
+	    "disabled");
+        return 1; /* FAILED */
+    }
     if(section->min_proto_version &&
             !SSL_CTX_set_min_proto_version(section->ctx,
             section->min_proto_version)) {


### PR DESCRIPTION
`SSL_CTX_new()` and `SSL_CTX_new_ex()` return `NULL` on error. If such condition happens, stunnel will erroneously report the `Failed to set the minimum protocol version` message. Luckily, `SSL_CTX_set_min_proto_version()` is ready to accept the `NULL` pointer so it does not crash. This change adds simple check of the result of `SSL_CTX` creation.