### PR TITLE
Fix "redirect" for protocols

### DIFF
--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -519,6 +519,9 @@ struct client_data_struct {
     unsigned long long seq;          /* sequential thread number for logging */
     unsigned rr;    /* per-client sequential number for round-robin failover */
 
+    uint8_t redirect_called;
+    uint8_t redirect_last_status;
+
     /* data for transfer() function */
     char sock_buff[BUFFSIZE];                          /* socket read buffer */
     char ssl_buff[BUFFSIZE];                              /* TLS read buffer */


### PR DESCRIPTION
During testing "socks5" protocol, I've discovered that "redirect" and "verifyPeer" settings do nothing and "socks5" port accepts any connections without proper validation of certificates and etc. You can literally write an application that establishes a TLS connection and uses socks5 proxy without any certificates validations.

I described it here: https://www.stunnel.org/mailman3/hyperkitty/list/stunnel-users@stunnel.org/thread/3VVUJGVZU6IWDNZ7RLEPJ6XAJYN35PEW/
